### PR TITLE
Fix templates path

### DIFF
--- a/cobbler/resource_cobbler_template_file.go
+++ b/cobbler/resource_cobbler_template_file.go
@@ -3,6 +3,7 @@ package cobbler
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	cobbler "github.com/wearespindle/cobblerclient"
@@ -32,9 +33,12 @@ func resourceTemplateFile() *schema.Resource {
 
 func resourceTemplateFileCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+	filePath := d.Get("name").(string)
+	filePathSplit := strings.Split(filePath, "/")
+	filename := filePathSplit[len(filePathSplit)-1]
 
 	ks := cobbler.TemplateFile{
-		Name: d.Get("name").(string),
+		Name: filename,
 		Body: d.Get("body").(string),
 	}
 


### PR DESCRIPTION
The file parameter passed to the cobbler XMLRPC write_autoinstall_template [must be relative](https://github.com/cobbler/cobbler/blob/0af8b9f839b4739473e2d5feee41d14827e13638/cobbler/autoinstall_manager.py#L118).  By passing the absolute path, templates are created in /var/lib/cobbler/templates/var/lib/cobbler/templates/  (directory path is repeated).

In this case the path is relative from /var/lib/cobbler/templates/, in other words, needs to be just the filename.  There might be other places this needs fixing, but this solves the immediate problem I'm having